### PR TITLE
Add dealer CRUD endpoints and schemas

### DIFF
--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -5,6 +5,7 @@ from .auth import router as auth_router
 from .collections import router as collections_router
 from .items import router as items_router
 from .users import router as users_router
+from .dealers import router as dealers_router
 
 http_bearer = HTTPBearer(auto_error=False)
 
@@ -13,3 +14,4 @@ router.include_router(auth_router)
 router.include_router(users_router)
 router.include_router(items_router)
 router.include_router(collections_router)
+router.include_router(dealers_router)

--- a/backend/src/api/routes/dealers.py
+++ b/backend/src/api/routes/dealers.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, HTTPException, status, Depends
+from sqlalchemy import select
+from api.dependency.database import SessionDependency
+from api.routes.fastapi_users import current_active_user
+from models import Dealer, User
+from schemas.dealer import DealerCreate, DealerRead, DealerUpdate
+
+
+router = APIRouter(prefix='/dealers', tags=['Dealers'])
+
+
+@router.get('/', response_model=list[DealerRead])
+async def get_dealers(session: SessionDependency, current_user: User = Depends(current_active_user)):
+    result = await session.execute(select(Dealer).where(Dealer.user_id == current_user.id).order_by(Dealer.name))
+    return result.scalars().all()
+
+
+@router.get('/{dealer_id}', response_model=DealerRead)
+async def get_dealer(dealer_id: int, session: SessionDependency, current_user: User = Depends(current_active_user)):
+    dealer = await session.get(Dealer, dealer_id)
+    if not dealer or dealer.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Dealer not found")
+
+    return dealer
+
+
+@router.post('/', response_model=DealerRead, status_code=status.HTTP_201_CREATED)
+async def create_dealer(dealer_data: DealerCreate, session: SessionDependency, current_user: User = Depends(current_active_user)):
+    dealer = Dealer(**dealer_data.model_dump(), user_id=current_user.id)
+    session.add(dealer)
+    await session.commit()
+    await session.refresh(dealer)
+    return dealer
+
+
+@router.put('/{dealer_id}', response_model=DealerRead)
+async def update_dealer(dealer_id: int, dealer_data: DealerUpdate, session: SessionDependency, current_user: User = Depends(current_active_user)):
+    dealer = await session.get(Dealer, dealer_id)
+    if not dealer or dealer.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Dealer not found")
+
+    update_data = dealer_data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(dealer, field, value)
+
+    await session.commit()
+    await session.refresh(dealer)
+    return dealer
+
+
+@router.delete('/{dealer_id}', status_code=status.HTTP_204_NO_CONTENT)
+async def delete_dealer(dealer_id: int, session: SessionDependency, current_user: User = Depends(current_active_user)):
+    dealer = await session.get(Dealer, dealer_id)
+    if not dealer or dealer.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Dealer not found")
+
+    await session.delete(dealer)
+    await session.commit()

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,7 +1,8 @@
-__all__ = ('Base', 'User', 'AccessToken', 'Item', 'Collection')
+__all__ = ('Base', 'User', 'AccessToken', 'Item', 'Collection', 'Dealer')
 
 from .access_token import AccessToken
 from .base import Base
 from .collection import Collection
 from .item import Item
 from .user import User
+from .dealer import Dealer

--- a/backend/src/models/dealer.py
+++ b/backend/src/models/dealer.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import String, ForeignKey
+from .base import Base
+from .mixins.id_int_pk import IdIntPkMixin
+
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class Dealer(Base, IdIntPkMixin):
+    __tablename__ = 'dealers'
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    address: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    website: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    note: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey('users.id'), nullable=False)
+
+    user: Mapped['User'] = relationship('User', lazy='select')

--- a/backend/src/schemas/dealer.py
+++ b/backend/src/schemas/dealer.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+from pydantic import BaseModel, Field
+
+
+class DealerBase(BaseModel):
+    name: Annotated[str, Field(min_length=1, max_length=255, description="Dealer name")]
+    email: Annotated[str | None, Field(description="Email address")]=None
+    phone: Annotated[str | None, Field(description="Phone number")]=None
+    address: Annotated[str | None, Field(description="Postal address")]=None
+    website: Annotated[str | None, Field(description="Website")]=None
+    note: Annotated[str | None, Field(description="Custom note")]=None
+
+
+class DealerCreate(DealerBase):
+    pass
+
+
+class DealerUpdate(BaseModel):
+    name: Annotated[str | None, Field(min_length=1, max_length=255, description="Dealer name")] = None
+    email: Annotated[str | None, Field(description="Email address")] = None
+    phone: Annotated[str | None, Field(description="Phone number")] = None
+    address: Annotated[str | None, Field(description="Postal address")] = None
+    website: Annotated[str | None, Field(description="Website")] = None
+    note: Annotated[str | None, Field(description="Custom note")] = None
+
+
+class DealerRead(DealerBase):
+    id: int
+    user_id: int

--- a/backend/src/tests/test_dealers.py
+++ b/backend/src/tests/test_dealers.py
@@ -1,0 +1,93 @@
+import pytest
+from fastapi import status
+from models.dealer import Dealer
+
+
+@pytest.mark.asyncio
+class TestDealersEndpoints:
+    async def test_create_dealer(self, authenticated_client, test_user, test_session):
+        data = {
+            "name": "DealerTest",
+            "email": "dealer@test.com",
+            "phone": "+1234567890",
+            "address": "123 Main St",
+            "website": "https://dealer.com",
+            "note": "My favorite dealer"
+        }
+        response = authenticated_client.post("/api/dealers/", json=data)
+        assert response.status_code == status.HTTP_201_CREATED
+        dealer = response.json()
+        assert dealer["name"] == data["name"]
+        assert dealer["email"] == data["email"]
+        assert dealer["phone"] == data["phone"]
+        assert dealer["address"] == data["address"]
+        assert dealer["website"] == data["website"]
+        assert dealer["note"] == data["note"]
+        # Check in DB
+        result = await test_session.execute(
+            Dealer.__table__.select().where(Dealer.name == data["name"]))
+        db_dealer = result.first()
+        assert db_dealer is not None
+
+    async def test_get_dealers(self, authenticated_client, test_user, test_session):
+        dealer = Dealer(
+            name="DealerList",
+            email="list@test.com",
+            phone=None,
+            address=None,
+            website=None,
+            note=None,
+            user_id=test_user.id
+        )
+        test_session.add(dealer)
+        await test_session.commit()
+        response = authenticated_client.get("/api/dealers/")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert any(d["name"] == "DealerList" for d in data)
+
+    async def test_get_dealer_by_id(self, authenticated_client, test_user, test_session):
+        dealer = Dealer(name="DealerById", email=None, phone=None, address=None, website=None, note=None, user_id=test_user.id)
+        test_session.add(dealer)
+        await test_session.commit()
+        await test_session.refresh(dealer)
+        response = authenticated_client.get(f"/api/dealers/{dealer.id}")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == "DealerById"
+        assert data["note"] is None
+
+    async def test_update_dealer(self, authenticated_client, test_user, test_session):
+        dealer = Dealer(name="DealerUpd", email=None, phone=None, address=None, website=None, note=None, user_id=test_user.id)
+        test_session.add(dealer)
+        await test_session.commit()
+        await test_session.refresh(dealer)
+        update = {
+            "name": "DealerUpdated",
+            "email": "upd@test.com",
+            "phone": "+9876543210",
+            "address": "456 New St",
+            "website": "https://upd.com",
+            "note": "Updated note"
+        }
+        response = authenticated_client.put(f"/api/dealers/{dealer.id}", json=update)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == update["name"]
+        assert data["email"] == update["email"]
+        assert data["phone"] == update["phone"]
+        assert data["address"] == update["address"]
+        assert data["website"] == update["website"]
+        assert data["note"] == update["note"]
+
+    async def test_delete_dealer(self, authenticated_client, test_user, test_session):
+        dealer = Dealer(name="DealerDel", email=None, phone=None, address=None, website=None, note=None, user_id=test_user.id)
+        test_session.add(dealer)
+        await test_session.commit()
+        await test_session.refresh(dealer)
+        response = authenticated_client.delete(f"/api/dealers/{dealer.id}")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        # Check not in DB
+        result = await test_session.execute(
+            Dealer.__table__.select().where(Dealer.id == dealer.id))
+        assert result.first() is None


### PR DESCRIPTION
- Implemented Dealer model, Pydantic schemas, and all CRUD API endpoints for dealers.
- Connected dealer router to the main API router.
- Added async tests for all dealer operations.
- Now users can create, update, list, get, and delete their own dealers.