### PR TITLE
Add PriceHistory functionality

### DIFF
--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -6,6 +6,7 @@ from .collections import router as collections_router
 from .items import router as items_router
 from .users import router as users_router
 from .dealers import router as dealers_router
+from .price_history import router as price_history_router
 
 http_bearer = HTTPBearer(auto_error=False)
 
@@ -15,3 +16,4 @@ router.include_router(users_router)
 router.include_router(items_router)
 router.include_router(collections_router)
 router.include_router(dealers_router)
+router.include_router(price_history_router)

--- a/backend/src/api/routes/price_history.py
+++ b/backend/src/api/routes/price_history.py
@@ -1,0 +1,162 @@
+import uuid
+from fastapi import APIRouter, Depends, HTTPException, status, Path
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from datetime import datetime, timezone
+from models.price_history import PriceHistory
+from models.item import Item
+from schemas.price_history import PriceHistoryCreate, PriceHistoryRead, PriceHistoryBase
+from api.dependency.database import get_session
+from api.routes.fastapi_users import current_active_user
+from models.user import User
+
+
+router = APIRouter(prefix="/price-history", tags=["PriceHistory"])
+
+
+@router.post("/", response_model=PriceHistoryRead)
+async def create_price_history(
+    item_id: str,
+    price_history: PriceHistoryCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+):
+    try:
+        item_uuid = uuid.UUID(item_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid item_id format")
+
+    item = await session.scalar(select(Item).where(Item.id == str(item_uuid), Item.user_id == user.id))
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found or not owned by user")
+
+    # BUSINESS RULE: If there is already an OUT price, forbid adding new price history
+    out_exists = await session.scalar(select(PriceHistory).where(PriceHistory.item_id == item_uuid, PriceHistory.price_type == 'out'))
+    if out_exists:
+        raise HTTPException(status_code=403, detail="Cannot add price history after sale (OUT price exists)")
+
+    db_obj = PriceHistory(
+        item_id=item_uuid,
+        price=price_history.price,
+        price_type=price_history.price_type,
+        timestamp=price_history.timestamp or datetime.now(timezone.utc),
+        note=price_history.note,
+    )
+    session.add(db_obj)
+    await session.commit()
+    await session.refresh(db_obj)
+    return PriceHistoryRead.model_validate({
+        "id": str(db_obj.id),
+        "item_id": str(db_obj.item_id),
+        "price": db_obj.price,
+        "price_type": str(db_obj.price_type),
+        "timestamp": db_obj.timestamp,
+        "note": db_obj.note,
+    })
+
+
+@router.get("/item/{item_id}", response_model=list[PriceHistoryRead])
+async def get_price_history_for_item(
+    item_id: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+):
+    try:
+        item_uuid = uuid.UUID(item_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid item_id format")
+
+    item = await session.scalar(select(Item).where(Item.id == str(item_uuid), Item.user_id == user.id))
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found or not owned by user")
+
+    result = await session.execute(select(PriceHistory).where(PriceHistory.item_id == item_uuid))
+    items = result.scalars().all()
+    return [
+        PriceHistoryRead.model_validate({
+            "id": str(obj.id),
+            "item_id": str(obj.item_id),
+            "price": obj.price,
+            "price_type": str(obj.price_type),
+            "timestamp": obj.timestamp,
+            "note": obj.note,
+        }) for obj in items
+    ]
+
+
+class PriceHistoryUpdate(PriceHistoryBase):
+    pass
+
+
+@router.patch("/{price_history_id}", response_model=PriceHistoryRead)
+async def update_price_history(
+    price_history_id: str,
+    price_history: PriceHistoryUpdate = None,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+):
+    try:
+        price_history_uuid = uuid.UUID(price_history_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid price_history_id format")
+
+    db_obj = await session.get(PriceHistory, str(price_history_uuid))
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="PriceHistory not found")
+
+    # Check user owns the item
+    item = await session.scalar(select(Item).where(Item.id == str(db_obj.item_id), Item.user_id == user.id))
+    if not item:
+        raise HTTPException(status_code=403, detail="Not allowed to edit this price history")
+
+    # BUSINESS RULE: If there is an OUT price for this item, forbid any update
+    out_exists = await session.scalar(select(PriceHistory).where(PriceHistory.item_id == db_obj.item_id, PriceHistory.price_type == 'out'))
+    if out_exists:
+        raise HTTPException(status_code=403, detail="Cannot update price history after sale (OUT price exists)")
+
+    update_data = price_history.model_dump(exclude_unset=True)
+    # BUSINESS RULE: For IN or OUT, forbid changing timestamp
+    if db_obj.price_type in ('in', 'out') and 'timestamp' in update_data:
+        raise HTTPException(status_code=403, detail="Cannot change timestamp for IN or OUT price history record")
+    for field, value in update_data.items():
+        setattr(db_obj, field, value)
+
+    await session.commit()
+    await session.refresh(db_obj)
+    return PriceHistoryRead.model_validate({
+        "id": str(db_obj.id),
+        "item_id": str(db_obj.item_id),
+        "price": db_obj.price,
+        "price_type": str(db_obj.price_type),
+        "timestamp": db_obj.timestamp,
+        "note": db_obj.note,
+    })
+
+
+@router.delete("/{price_history_id}", status_code=204)
+async def delete_price_history(
+    price_history_id: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_active_user),
+):
+    try:
+        price_history_uuid = uuid.UUID(price_history_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid price_history_id format")
+
+    db_obj = await session.get(PriceHistory, str(price_history_uuid))
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="PriceHistory not found")
+
+    # Check user owns the item
+    item = await session.scalar(select(Item).where(Item.id == str(db_obj.item_id), Item.user_id == user.id))
+    if not item:
+        raise HTTPException(status_code=403, detail="Not allowed to delete this price history")
+
+    # BUSINESS RULE: If there is an OUT price for this item, forbid any delete
+    out_exists = await session.scalar(select(PriceHistory).where(PriceHistory.item_id == db_obj.item_id, PriceHistory.price_type == 'out'))
+    if out_exists:
+        raise HTTPException(status_code=403, detail="Cannot delete price history after sale (OUT price exists)")
+
+    await session.delete(db_obj)
+    await session.commit()

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ('Base', 'User', 'AccessToken', 'Item', 'Collection', 'Dealer')
+__all__ = ('Base', 'User', 'AccessToken', 'Item', 'Collection', 'Dealer', 'PriceHistory')
 
 from .access_token import AccessToken
 from .base import Base
@@ -6,3 +6,4 @@ from .collection import Collection
 from .item import Item
 from .user import User
 from .dealer import Dealer
+from .price_history import PriceHistory

--- a/backend/src/models/item.py
+++ b/backend/src/models/item.py
@@ -37,3 +37,4 @@ class Item(Base, UuidPkMixin):
         back_populates='items',
         lazy='select'
     )
+    price_history = relationship('PriceHistory', back_populates='item', cascade='all, delete-orphan')

--- a/backend/src/models/price_history.py
+++ b/backend/src/models/price_history.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timezone
+from sqlalchemy import ForeignKey, Numeric, DateTime, Enum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+from utils.enums import PriceType
+from .base import Base
+from .mixins.uuid_pk import UuidPkMixin
+
+
+class PriceHistory(Base, UuidPkMixin):
+    __tablename__ = 'price_history'
+
+    item_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey('items.id'), nullable=False)
+    price: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    price_type: Mapped[PriceType] = mapped_column(Enum(PriceType), nullable=False)
+    note: Mapped[str | None] = mapped_column(nullable=True)
+
+    item = relationship('Item', back_populates='price_history')

--- a/backend/src/schemas/item.py
+++ b/backend/src/schemas/item.py
@@ -1,5 +1,6 @@
 from typing import Annotated
 from pydantic import Field
+from datetime import datetime
 
 from schemas.base import SchemaConfigMixin
 from utils.enums import Material
@@ -16,7 +17,8 @@ class ItemBase(SchemaConfigMixin):
 
 
 class ItemCreate(ItemBase):
-    pass
+    purchase_price: Annotated[float | None, Field(gt=0, description="Purchase price (optional)")] = None
+    purchase_date: Annotated[datetime | None, Field(description="Purchase date (optional)")] = None
 
 
 class ItemUpdate(SchemaConfigMixin):

--- a/backend/src/schemas/price_history.py
+++ b/backend/src/schemas/price_history.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+from typing import Annotated
+from pydantic import BaseModel, Field, ConfigDict, field_serializer
+from utils.enums import PriceType
+
+
+class PriceHistoryBase(BaseModel):
+    price: Annotated[float, Field(gt=0, description="Price value")]
+    price_type: Annotated[PriceType, Field(description="Type of price (in, out, current)")]
+    timestamp: Annotated[datetime | None, Field(description="Timestamp for the price record")] = None
+    note: Annotated[str | None, Field(description="Comment or resource for the price (optional)")] = None
+
+
+class PriceHistoryCreate(PriceHistoryBase):
+    pass
+
+
+class PriceHistoryRead(BaseModel):
+    id: str
+    item_id: str
+    price: float
+    price_type: str
+    timestamp: datetime
+    note: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer('timestamp')
+    def serialize_timestamp(self, value: datetime, _info):
+        if value is None:
+            return None
+
+        # Ensure ISO8601 output with timezone (if no tzinfo, add +00:00)
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+
+        return value.isoformat()
+
+
+class PriceHistoryUpdate(PriceHistoryBase):
+    pass

--- a/backend/src/tests/test_price_history.py
+++ b/backend/src/tests/test_price_history.py
@@ -1,0 +1,203 @@
+import pytest
+from httpx import AsyncClient
+from utils.enums import PriceType
+import datetime
+from datetime import datetime, timezone, timedelta
+import uuid
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_price_history(authenticated_client, test_item):
+    payload = {
+        "price": 100.5,
+        "price_type": "in"
+    }
+
+    item_id = str(test_item.id) if not isinstance(test_item.id, str) else test_item.id
+    response = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["price"] == 100.5
+    assert data["price_type"] == "in"
+    # Get price history for item
+    response = authenticated_client.get(f"/api/price-history/item/{item_id}")
+    assert response.status_code == 200
+    items = response.json()
+    assert any(ph["price_type"] == "in" and ph["price"] == 100.5 for ph in items)
+
+
+@pytest.mark.asyncio
+async def test_full_price_history_cycle(authenticated_client, test_item):
+    item_id = str(test_item.id) if not isinstance(test_item.id, str) else test_item.id
+
+    # Simulate purchase (in)
+    purchase_payload = {
+        "price": 150.0,
+        "price_type": "in",
+        "timestamp": (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    }
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=purchase_payload)
+    assert resp.status_code == 200
+    purchase_id = resp.json()["id"]
+
+    # Simulate sale (out)
+    sale_payload = {
+        "price": 500.0,
+        "price_type": "out",
+        "timestamp": (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    }
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=sale_payload)
+    assert resp.status_code == 200
+    sale_id = resp.json()["id"]
+
+    # After OUT price, any new price history should be forbidden
+    current_3mo_payload = {
+        "price": 200.0,
+        "price_type": "current",
+        "timestamp": (datetime.now(timezone.utc) - timedelta(days=90)).isoformat()
+    }
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=current_3mo_payload)
+    assert resp.status_code == 403
+
+    # Optionally, check that other types are also forbidden
+    current_2mo_payload = {
+        "price": 250.0,
+        "price_type": "current",
+        "timestamp": (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    }
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=current_2mo_payload)
+    assert resp.status_code == 403
+
+    # Optionally, check that auction/old price is forbidden
+    auction_payload = {
+        "price": 3000.0,
+        "price_type": "current",
+        "timestamp": datetime(1992, 5, 20, 12, 0, 0, tzinfo=timezone.utc).isoformat()
+    }
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=auction_payload)
+    assert resp.status_code == 403
+
+    # Get all price history for item
+    resp = authenticated_client.get(f"/api/price-history/item/{item_id}")
+    assert resp.status_code == 200
+    items = resp.json()
+    # Check only IN and OUT prices exist
+    assert any(ph["price_type"] == "in" and ph["price"] == 150.0 for ph in items)
+    assert any(ph["price_type"] == "out" and ph["price"] == 500.0 for ph in items)
+
+
+@pytest.mark.asyncio
+async def test_update_price_history(authenticated_client, test_item):
+    item_id = str(test_item.id) if not isinstance(test_item.id, str) else test_item.id
+    # Create price history record
+    payload = {
+        "price": 123.45,
+        "price_type": "current"
+    }
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    price_history_id = data["id"]
+    # Update price, price_type, and timestamp
+    update_payload = {
+        "price": 543.21,
+        "price_type": "out",
+        "timestamp": "2020-01-01T12:00:00"
+    }
+    resp = authenticated_client.patch(f"/api/price-history/{price_history_id}", json=update_payload)
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["price"] == 543.21
+    assert updated["price_type"] == "out"
+    assert updated["timestamp"].startswith("2020-01-01T12:00:00")
+
+
+def test_create_price_history_for_nonexistent_item(authenticated_client):
+    non_existent_id = str(uuid.uuid4())
+    payload = {"price": 99.99, "price_type": "in"}
+    resp = authenticated_client.post(f"/api/price-history/?item_id={non_existent_id}", json=payload)
+    assert resp.status_code in (404, 422)  # depends on backend logic
+
+
+def test_get_price_history_for_nonexistent_item(authenticated_client):
+    non_existent_id = str(uuid.uuid4())
+    resp = authenticated_client.get(f"/api/price-history/item/{non_existent_id}")
+    assert resp.status_code == 404
+
+
+def test_price_history_serialization(authenticated_client, test_item):
+    payload = {"price": 123.45, "price_type": "current"}
+    resp = authenticated_client.post(f"/api/price-history/?item_id={test_item.id}", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "id" in data
+    assert "item_id" in data
+    assert "price" in data
+    assert "price_type" in data
+    assert "timestamp" in data
+    # Check timezone-aware
+    assert data["timestamp"].endswith("+00:00")
+
+
+def test_create_price_history_with_invalid_price_type(authenticated_client, test_item):
+    payload = {"price": 10.0, "price_type": "invalid_type"}
+    resp = authenticated_client.post(f"/api/price-history/?item_id={test_item.id}", json=payload)
+    assert resp.status_code == 422
+
+
+def test_create_price_history_missing_required_fields(authenticated_client, test_item):
+    payload = {"price_type": "in"}  # no price
+    resp = authenticated_client.post(f"/api/price-history/?item_id={test_item.id}", json=payload)
+    assert resp.status_code == 422
+    payload = {"price": 10.0}  # no price_type
+    resp = authenticated_client.post(f"/api/price-history/?item_id={test_item.id}", json=payload)
+    assert resp.status_code == 422
+
+
+def test_forbid_timestamp_update_for_in_or_out(authenticated_client, test_item):
+    item_id = str(test_item.id) if not isinstance(test_item.id, str) else test_item.id
+    # Create IN price
+    payload = {"price": 111.0, "price_type": "in"}
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    price_history_id = data["id"]
+    # Try to update timestamp for IN price (with a different valid price and price_type)
+    update_payload = {"price": 112.0, "price_type": "in", "timestamp": "2022-01-01T12:00:00"}
+    resp = authenticated_client.patch(f"/api/price-history/{price_history_id}", json=update_payload)
+    assert resp.status_code == 403
+
+    # Create OUT price
+    payload = {"price": 222.0, "price_type": "out"}
+    resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    price_history_id = data["id"]
+    # Try to update timestamp for OUT price (with a different valid price and price_type)
+    update_payload = {"price": 223.0, "price_type": "out", "timestamp": "2023-01-01T12:00:00"}
+    resp = authenticated_client.patch(f"/api/price-history/{price_history_id}", json=update_payload)
+    assert resp.status_code == 403
+
+
+def test_price_history_deleted_with_item(authenticated_client, test_item):
+    item_id = str(test_item.id) if not isinstance(test_item.id, str) else test_item.id
+    # Add price history records
+    payloads = [
+        {"price": 10.0, "price_type": "in"},
+        {"price": 20.0, "price_type": "current"}
+    ]
+    for payload in payloads:
+        resp = authenticated_client.post(f"/api/price-history/?item_id={item_id}", json=payload)
+        assert resp.status_code == 200
+
+    # Check price history exists
+    resp = authenticated_client.get(f"/api/price-history/item/{item_id}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 2
+    # Delete item
+    resp = authenticated_client.delete(f"/api/items/{item_id}")
+    assert resp.status_code == 204
+    # Check price history is deleted
+    resp = authenticated_client.get(f"/api/price-history/item/{item_id}")
+    assert resp.status_code == 404

--- a/backend/src/utils/enums.py
+++ b/backend/src/utils/enums.py
@@ -24,3 +24,9 @@ class ErrorCode(StrEnum):
     INTERNAL_DATABASE_ERROR = '100003'
     DUPLICATE_RECORD_ERROR = '100004'
     NOT_FOUND_RECORD_ERROR = '100005'
+
+
+class PriceType(StrEnum):
+    IN = 'in'
+    OUT = 'out'
+    CURRENT = 'current'


### PR DESCRIPTION
**Commit title:**
Add PriceHistory functionality

- Implemented PriceHistory entity: model, schemas, CRUD routes, serialization
- Added note (comment) field
- After OUT (sale) price, all changes/additions/deletions to price_history for the item are forbidden
- Timestamp cannot be changed for IN/OUT price types
- Cascade delete: price_history records are deleted when item is deleted
- All business cases covered by tests: forbidden actions after OUT, timestamp update restriction, cascade delete, serialization, validation, non-existent item handling.